### PR TITLE
Typo in Netbox Platform creation

### DIFF
--- a/Sync-Netbox.ps1
+++ b/Sync-Netbox.ps1
@@ -232,7 +232,7 @@ function Sync-Netbox {
                         $PlatformJSON = ConvertTo-JSON $PlatformInfo
                         Write-Verbose $PlatformJSON
                         $URI = $URIBase + $PlatformsPath + "/"
-                        $Response = Invoke-RESTMethod -Method POST -Headers $Headers -ContentType "application/json" -Body $PlatormJSON -URI $URI
+                        $Response = Invoke-RESTMethod -Method POST -Headers $Headers -ContentType "application/json" -Body $PlatformJSON -URI $URI
                         ConvertTo-JSON $Response | Write-Verbose
                         # add new id into platforms hashtable
                         $NetboxPlatforms[$Response.Name] = $Response.ID


### PR DESCRIPTION
Fixed a small typo in the netbox API call to create the missing Platforms